### PR TITLE
ci: update node matrix to current LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,13 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 12
-          - 14
-          - 16
+          - 20
+          - 22
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm


### PR DESCRIPTION
## Summary

- Bump test matrix from EOL Node 12/14/16 to active LTS 20/22.
- Bump `actions/checkout` and `actions/setup-node` to v4 to match `release.yml`.

## Why

Dependabot PRs (e.g. #42) currently fail with `npm ERR! Cannot read property '@octokit/core' of undefined` on `test (12)` and `test (14)`. Root cause: Dependabot regenerates `package-lock.json` at `lockfileVersion: 3`, which the npm 6.x bundled with Node 12/14 cannot parse. `main` still passes only because its lockfile is at `lockfileVersion: 1`, but every dependency-update PR will fail until the matrix is moved off EOL Node.

Node 12 (EOL April 2022), 14 (EOL April 2023), and 16 (EOL September 2023) are all unsupported. 20 and 22 are the current LTS lines.

## Follow-up required

Branch protection on `main` currently lists `test (12)` and `test (14)` as required status checks. After this merges, those rules need to be updated to `test (20)` / `test (22)` (or a single rolled-up check) or PRs will become unmergeable.

## Test plan

- [ ] CI runs `test (20)` and `test (22)` on this PR and both pass.
- [ ] After merging and updating branch protection, retrigger Dependabot PR #42 to confirm it now passes.